### PR TITLE
Freeze Package Versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,6 @@ FROM python:3.7
 ADD . ./
 
 RUN pip install -r requirements.txt
+RUN apt update && apt install jq -y
 
 ENTRYPOINT ["python", "./phoca"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-tqdm
-tldextract
+tqdm==4.62.3
+tldextract==3.1.2
 sslyze==2.1.4
-pandas
+pandas==1.3.4
 scikit-learn==1.0


### PR DESCRIPTION
New versions of various packages have deprecated a lot of the functions that phoca depends on. This PR fixes build errors by freezing versions to the ones that were available at the time of the project's creation. 